### PR TITLE
Fixes issue #44 where test-report.css is cut off at 8 KB

### DIFF
--- a/src/main/java/io/xspec/maven/xspecMavenPlugin/XSpecRunner.java
+++ b/src/main/java/io/xspec/maven/xspecMavenPlugin/XSpecRunner.java
@@ -858,6 +858,8 @@ public class XSpecRunner implements LogProvider {
                 bos.write(buffer, 0, read);
                 read = is.read(buffer);
             }
+            is.close();
+            bos.close();
         } catch(TransformerException ex) {
             getLog().error("while extracting CSS: ",ex);
         }


### PR DESCRIPTION
After some initial issues due to Java 9+ (more on that in another issue), I've been able test my suspicions and was able to confirm that closing the BufferedOutputStream does indeed fix the partial copy of the test-report.css file.

I've closed the BufferedInputStream as well for good measure.