### PR TITLE
#68 Missing surefire reports due to tests targetting the same xslts

### DIFF
--- a/src/main/java/io/xspec/maven/xspecMavenPlugin/XSpecRunner.java
+++ b/src/main/java/io/xspec/maven/xspecMavenPlugin/XSpecRunner.java
@@ -245,9 +245,9 @@ public class XSpecRunner implements LogProvider {
                 if(xmlStuff.getXeSurefire()!=null) {
                     XsltTransformer xt = xmlStuff.getXeSurefire().load();
                     try {
-                        xt.setParameter(new QName("baseDir"), new XdmAtomicValue(baseDirectory.toURI().toURL().toExternalForm()));
+                        xt.setParameter(new QName("baseDir"), new XdmAtomicValue(options.testDir.toURI().toURL().toExternalForm()));
                         xt.setParameter(new QName("outputDir"), new XdmAtomicValue(options.surefireReportDir.toURI().toURL().toExternalForm()));
-                        xt.setParameter(new QName("reportFileName"), new XdmAtomicValue(xspecXmlResult.getName()));
+                        xt.setParameter(new QName("xspecUri"), new XdmAtomicValue(sourceFile.toURI().toURL().toExternalForm()));
                         xt.setDestination(xmlStuff.newSerializer(new NullOutputStream()));
                         xtSurefire = xt;
                     } catch(MalformedURLException ex) {
@@ -416,10 +416,9 @@ public class XSpecRunner implements LogProvider {
                 XsltTransformer xt = xmlStuff.getXeSurefire().load();
                 xt.setErrorListener(errorListener);
                 try {
-                    xt.setParameter(new QName("baseDir"), new XdmAtomicValue(baseDirectory.toURI().toURL().toExternalForm()));
-                    // issue #40
+                    xt.setParameter(new QName("baseDir"), new XdmAtomicValue(options.testDir.toURI().toURL().toExternalForm()));
                     xt.setParameter(new QName("outputDir"), new XdmAtomicValue(options.surefireReportDir.toURI().toURL().toExternalForm()));
-                    xt.setParameter(new QName("reportFileName"), new XdmAtomicValue(xspecXmlResult.getName()));
+                    xt.setParameter(new QName("xspecUri"), new XdmAtomicValue(sourceFile.toURI().toURL().toExternalForm()));
                     xt.setDestination(xmlStuff.newSerializer(new NullOutputStream()));
                     xtSurefire = xt;
                 } catch(MalformedURLException ex) {
@@ -574,10 +573,9 @@ public class XSpecRunner implements LogProvider {
                 XsltTransformer xt = xmlStuff.getXeSurefire().load();
                 xt.setErrorListener(errorListener);
                 try {
-                    xt.setParameter(new QName("baseDir"), new XdmAtomicValue(baseDirectory.toURI().toURL().toExternalForm()));
-                    // issue #40
+                    xt.setParameter(new QName("baseDir"), new XdmAtomicValue(options.testDir.toURI().toURL().toExternalForm()));
                     xt.setParameter(new QName("outputDir"), new XdmAtomicValue(options.surefireReportDir.toURI().toURL().toExternalForm()));
-                    xt.setParameter(new QName("reportFileName"), new XdmAtomicValue(xspecXmlResult.getName()));
+                    xt.setParameter(new QName("xspecUri"), new XdmAtomicValue(sourceFile.toURI().toURL().toExternalForm()));
                     xt.setDestination(xmlStuff.newSerializer(new NullOutputStream()));
                     xtSurefire = xt;
                 } catch(MalformedURLException ex) {

--- a/src/test/java/io/xspec/maven/xspecMavenPlugin/XSpecRunnerTest.java
+++ b/src/test/java/io/xspec/maven/xspecMavenPlugin/XSpecRunnerTest.java
@@ -82,7 +82,9 @@ public class XSpecRunnerTest extends TestUtils {
 
     @Test
     public void processXsltXspecTest() throws Exception {
-        XSpecRunner runner = getNewRunner(new SaxonOptions());
+        RunnerOptions options = new RunnerOptions(getBaseDirectory());
+        options.testDir = new File(getProjectDirectory(), "src/test/resources/filesToTest/xsltTestCase");
+        XSpecRunner runner = getNewRunner(new SaxonOptions(), options);
         File xspecFile = new File(getBaseDirectory().getParentFile().getParentFile().getParentFile(), "src/test/resources/filesToTest/xsltTestCase/xsl1.xspec");
         XdmNode node = runner.getXmlStuff().getDocumentBuilder().build(xspecFile);
         assertNotNull("node is null", node);
@@ -94,6 +96,7 @@ public class XSpecRunnerTest extends TestUtils {
     @Test
     public void generateIndexWithXsltTest() throws Exception {
         RunnerOptions options = new RunnerOptions(getBaseDirectory());
+        options.testDir = new File(getProjectDirectory(), "src/test/resources/filesToTest/xsltTestCase");
         XSpecRunner runner = getNewRunner(new SaxonOptions(), options);
         File xspecFile = new File(getBaseDirectory().getParentFile().getParentFile().getParentFile(), "src/test/resources/filesToTest/xsltTestCase/xsl1.xspec");
         XdmNode node = runner.getXmlStuff().getDocumentBuilder().build(xspecFile);


### PR DESCRIPTION
As explained in issue #68, the use of the target xslt for thegeneration of the surefire reports has the effect that you are missing reports when more than one xspec targets the same xslt. This pull request changes that behaviour. I've also improved the generated surefire reports while I was at it.

Important note: I wasn't able to build this due to issues in `XSpecCompilerTest.prepareSchematronDocumentTest` from one of the previous commits. That build failure was also present without my changes, so that has nothing to do with this pull request.

I also had to add the testDir to two unit tests in XSpecRunnerTest as that situation made it impossible to determine the package for the surefire tests and the XSpecMojo doesn't make it possible to end up in such a situation.