### PR TITLE
Add unit test to show missing Surefire report information on processing failures

### DIFF
--- a/src/test/resources/filesToTest/failingXslt/xsl1.xsl
+++ b/src/test/resources/filesToTest/failingXslt/xsl1.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+  xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+  xmlns:private="io:xspec:xspec-maven-plugin:tests"
+  exclude-result-prefixes="xs math xd"
+  version="3.0">
+  
+  <xsl:function name="private:add" as="xs:integer">
+    <xsl:param name="n1" as="xs:integer"/>
+    <xsl:param name="n2" as="xs:integer"/>
+    <xsl:message terminate="yes"/>
+  </xsl:function>
+  
+</xsl:stylesheet>

--- a/src/test/resources/filesToTest/failingXslt/xsl1.xspec
+++ b/src/test/resources/filesToTest/failingXslt/xsl1.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description 
+  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:private="io:xspec:xspec-maven-plugin:tests"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  stylesheet="xsl1.xsl">
+  
+  <x:scenario label="Testing function add">
+    <x:call function="private:add">
+      <x:param as="xs:integer" select="1"/>
+      <x:param as="xs:integer" select="4"/>
+    </x:call>
+    <x:expect label="5" select="5"/>
+  </x:scenario>
+</x:description>

--- a/src/test/resources/filesToTest/failingXslt/xsl2.xsl
+++ b/src/test/resources/filesToTest/failingXslt/xsl2.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  version="3.0">
+  
+  <xsl:
+  
+</xsl:stylesheet>

--- a/src/test/resources/filesToTest/failingXslt/xsl2.xspec
+++ b/src/test/resources/filesToTest/failingXslt/xsl2.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description 
+  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:private="io:xspec:xspec-maven-plugin:tests"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  stylesheet="xsl2.xsl">
+  
+  <x:scenario label="Testing function add">
+    <x:call function="private:add">
+      <x:param as="xs:integer" select="1"/>
+      <x:param as="xs:integer" select="4"/>
+    </x:call>
+    <x:expect label="5" select="5"/>
+  </x:scenario>
+</x:description>


### PR DESCRIPTION
According to issue #83 